### PR TITLE
[O2-2462] fix wrong entry in literals metadata

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -871,8 +871,8 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
       const size_t nSymbols = literals.size();
       if (!literals.empty()) {
         // introduce padding in case literals don't align;
-        const size_t nSourceElemsPadded = calculatePaddedSize<input_t, storageBuffer_t>(literals.size());
-        literals.resize(nSourceElemsPadded, {});
+        const size_t nLiteralSymbolsPadded = calculatePaddedSize<input_t, storageBuffer_t>(nSymbols);
+        literals.resize(nLiteralSymbolsPadded, {});
 
         const size_t nLiteralStorageElems = calculateNDestTElements<input_t, storageBuffer_t>(nSymbols);
         expandStorage(nLiteralStorageElems);
@@ -882,7 +882,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
     }();
 
     *thisMetadata = Metadata{messageLength,
-                             literals.size(),
+                             nLiteralSymbols,
                              sizeof(ransState_t),
                              sizeof(ransStream_t),
                              static_cast<uint8_t>(encoder->getSymbolTablePrecision()),
@@ -891,7 +891,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
                              encoder->getMaxSymbol(),
                              static_cast<int32_t>(frequencyTable.size()),
                              dataSize,
-                             static_cast<int32_t>(nLiteralSymbols)};
+                             static_cast<int32_t>(literals.size())};
   } else { // store original data w/o EEncoding
     //FIXME(milettri): we should be able to do without an intermediate vector;
     // provided iterator is not necessarily pointer, need to use intermediate vector!!!


### PR DESCRIPTION
the `Metadata` for literal symbols in `EncodedBlocks` is set wrongly - the values for `nLiteralSymbols`and `nLiteralWords` are swapped. This should fix the issue and the bugs it caused during decoding.