### PR TITLE
[EMCAL-729] Add compression of trigger bits

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -19,6 +19,7 @@
 #undef NDEBUG
 #include <cassert>
 #include <type_traits>
+#include <cstddef>
 #include <Rtypes.h>
 #include "rANS/rans.h"
 #include "rANS/utils.h"
@@ -138,9 +139,9 @@ struct Metadata {
 
 /// registry struct for the buffer start and offsets of writable space
 struct Registry {
-  char* head = nullptr;
+  char* head = nullptr;     //! pointer on the head of the CTF
   int nFilledBlocks = 0;    // number of filled blocks = next block to fill (must be strictly consecutive)
-  size_t offsFreeStart = 0; // offset of the start of the writable space (wrt head), in bytes!!!
+  size_t offsFreeStart = 0; //! offset of the start of the writable space (wrt head), in bytes!!!
   size_t size = 0;          // full size in bytes!!!
 
   /// calculate the pointer of the head of the writable space
@@ -341,6 +342,8 @@ class EncodedBlocks
   H& getHeader() { return mHeader; }
   std::shared_ptr<H> cloneHeader() const { return std::shared_ptr<H>(new H(mHeader)); } // for dictionary creation
 
+  const auto& getRegistry() const { return mRegistry; }
+
   const auto& getMetadata() const { return mMetadata; }
 
   auto& getMetadata(int i) const
@@ -448,7 +451,7 @@ class EncodedBlocks
  protected:
   static_assert(N > 0, "number of encoded blocks < 1");
 
-  Registry mRegistry;                //! not stored
+  Registry mRegistry;                //
   ANSHeader mANSHeader;              //  ANS header
   H mHeader;                         //  detector specific header
   std::array<Metadata, N> mMetadata; //  compressed block's details
@@ -479,9 +482,9 @@ class EncodedBlocks
 
   /// read single branch
   template <typename D>
-  static void readTreeBranch(TTree& tree, const std::string& brname, D& dt, int ev = 0);
+  static bool readTreeBranch(TTree& tree, const std::string& brname, D& dt, int ev = 0);
 
-  ClassDefNV(EncodedBlocks, 1);
+  ClassDefNV(EncodedBlocks, 2);
 };
 
 ///_____________________________________________________________________________
@@ -502,7 +505,9 @@ template <typename VD>
 void EncodedBlocks<H, N, W>::readFromTree(VD& vec, TTree& tree, const std::string& name, int ev)
 {
   auto tmp = create(vec);
-  readTreeBranch(tree, o2::utils::Str::concat_string(name, "_wrapper."), *tmp, ev);
+  if (!readTreeBranch(tree, o2::utils::Str::concat_string(name, "_wrapper."), *tmp, ev)) {
+    throw std::runtime_error(fmt::format("Failed to read CTF header for {}", name));
+  }
   tmp = tmp->expand(vec, tmp->estimateSizeFromMetadata());
   const auto& meta = tmp->getMetadata();
   for (int i = 0; i < N; i++) {
@@ -534,14 +539,18 @@ size_t EncodedBlocks<H, N, W>::appendToTree(TTree& tree, const std::string& name
 /// read single branch
 template <typename H, int N, typename W>
 template <typename D>
-inline void EncodedBlocks<H, N, W>::readTreeBranch(TTree& tree, const std::string& brname, D& dt, int ev)
+bool EncodedBlocks<H, N, W>::readTreeBranch(TTree& tree, const std::string& brname, D& dt, int ev)
 {
   auto* br = tree.GetBranch(brname.c_str());
-  assert(br);
+  if (!br) {
+    LOG(debug) << "Branch " << brname << " is absent";
+    return false;
+  }
   auto* ptr = &dt;
   br->SetAddress(&ptr);
   br->GetEntry(ev);
   br->ResetAddress();
+  return true;
 }
 
 ///_____________________________________________________________________________
@@ -713,9 +722,9 @@ template <typename H, int N, typename W>
 void EncodedBlocks<H, N, W>::print(const std::string& prefix, int verbosity) const
 {
   if (verbosity > 0) {
-    LOG(INFO) << prefix << "Container of " << N << " blocks, size: " << size() << " bytes, unused: " << getFreeSize();
+    LOG(info) << prefix << "Container of " << N << " blocks, size: " << size() << " bytes, unused: " << getFreeSize();
     for (int i = 0; i < N; i++) {
-      LOG(INFO) << "Block " << i << " for " << mMetadata[i].messageLength << " message words of " << mMetadata[i].messageWordSize << " bytes |"
+      LOG(info) << "Block " << i << " for " << mMetadata[i].messageLength << " message words of " << mMetadata[i].messageWordSize << " bytes |"
                 << " NDictWords: " << mBlocks[i].getNDict() << " NDataWords: " << mBlocks[i].getNData()
                 << " NLiteralWords: " << mBlocks[i].getNLiterals();
     }
@@ -727,7 +736,7 @@ void EncodedBlocks<H, N, W>::print(const std::string& prefix, int verbosity) con
       ndata += mBlocks[i].getNData();
       nlit += mBlocks[i].getNLiterals();
     }
-    LOG(INFO) << prefix << N << " blocks, input size: " << inpSize << ", output size: " << size()
+    LOG(info) << prefix << N << " blocks, input size: " << inpSize << ", output size: " << size()
               << " NDictWords: " << ndict << " NDataWords: " << ndata << " NLiteralWords: " << nlit;
   }
 }
@@ -760,7 +769,7 @@ void EncodedBlocks<H, N, W>::decode(D_IT dest,                    // iterator to
   if (block.getNStored()) {
     if (md.opt == Metadata::OptStore::EENCODE) {
       if (!decoderExt && !block.getNDict()) {
-        LOG(ERROR) << "Dictionaty is not saved for slot " << slot << " and no external decoder is provided";
+        LOG(error) << "Dictionaty is not saved for slot " << slot << " and no external decoder is provided";
         throw std::runtime_error("Dictionary is not saved and no external decoder provided");
       }
       const o2::rans::LiteralDecoder64<dest_t>* decoder = reinterpret_cast<const o2::rans::LiteralDecoder64<dest_t>*>(decoderExt);
@@ -772,7 +781,7 @@ void EncodedBlocks<H, N, W>::decode(D_IT dest,                    // iterator to
         decoder = decoderLoc.get();
       } else { // verify that decoded corresponds to stored metadata
         if (md.min != decoder->getMinSymbol() || md.max != decoder->getMaxSymbol()) {
-          LOG(ERROR) << "Mismatch between min=" << md.min << "/" << md.max << " symbols in metadata and those in external decoder "
+          LOG(error) << "Mismatch between min=" << md.min << "/" << md.max << " symbols in metadata and those in external decoder "
                      << decoder->getMinSymbol() << "/" << decoder->getMaxSymbol() << " for slot " << slot;
           throw std::runtime_error("Mismatch between min/max symbols in metadata and those in external decoder");
         }
@@ -843,7 +852,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
     auto* const blockHead = get(thisBlock->registry->head);                         // extract pointer from the block, as "this" might be invalid
     const size_t additionalSize = blockHead->estimateBlockSize(additionalElements); // size in bytes!!!
     if (additionalSize >= thisBlock->registry->getFreeSize()) {
-      LOG(DEBUG) << "Slot " << slot << ": free size: " << thisBlock->registry->getFreeSize() << ", need " << additionalSize << " for " << additionalElements << " words";
+      LOG(debug) << "Slot " << slot << ": free size: " << thisBlock->registry->getFreeSize() << ", need " << additionalSize << " for " << additionalElements << " words";
       if (buffer) {
         blockHead->expand(*buffer, blockHead->size() + (additionalSize - blockHead->getFreeSize()));
         thisMetadata = &(get(buffer->data())->mMetadata[slot]);
@@ -879,7 +888,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
     //store dictionary first
     if (frequencyTable.size()) {
       thisBlock->storeDict(frequencyTable.size(), frequencyTable.data());
-      LOGP(DEBUG, "StoreDict {} bytes, offs: {}:{}", frequencyTable.size() * sizeof(W), thisBlock->getOffsDict(), thisBlock->getOffsDict() + frequencyTable.size() * sizeof(W));
+      LOGP(debug, "StoreDict {} bytes, offs: {}:{}", frequencyTable.size() * sizeof(W), thisBlock->getOffsDict(), thisBlock->getOffsDict() + frequencyTable.size() * sizeof(W));
     }
     // vector of incompressible literal symbols
     std::vector<input_t> literals;
@@ -891,7 +900,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
     dataSize = encodedMessageEnd - thisBlock->getDataPointer();
     thisBlock->setNData(dataSize);
     thisBlock->realignBlock();
-    LOGP(DEBUG, "StoreData {} bytes, offs: {}:{}", dataSize * sizeof(W), thisBlock->getOffsData(), thisBlock->getOffsData() + dataSize * sizeof(W));
+    LOGP(debug, "StoreData {} bytes, offs: {}:{}", dataSize * sizeof(W), thisBlock->getOffsData(), thisBlock->getOffsData() + dataSize * sizeof(W));
     // update the size claimed by encode message directly inside the block
 
     // store incompressible symbols if any
@@ -906,7 +915,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
         const size_t nLiteralStorageElems = calculateNDestTElements<input_t, storageBuffer_t>(nSymbols);
         expandStorage(nLiteralStorageElems);
         thisBlock->storeLiterals(nLiteralStorageElems, reinterpret_cast<const storageBuffer_t*>(literals.data()));
-        LOGP(DEBUG, "StoreLiterals {} bytes, offs: {}:{}", nLiteralStorageElems * sizeof(W), thisBlock->getOffsLiterals(), thisBlock->getOffsLiterals() + nLiteralStorageElems * sizeof(W));
+        LOGP(debug, "StoreLiterals {} bytes, offs: {}:{}", nLiteralStorageElems * sizeof(W), thisBlock->getOffsLiterals(), thisBlock->getOffsLiterals() + nLiteralStorageElems * sizeof(W));
         return nLiteralStorageElems;
       }
       return size_t(0);
@@ -956,7 +965,7 @@ std::vector<char> EncodedBlocks<H, N, W>::createDictionaryBlocks(const std::vect
   auto dictBlocks = create(vdict.data(), sz);
   for (int ib = 0; ib < N; ib++) {
     if (vfreq[ib].size()) {
-      LOG(INFO) << "adding dictionary of " << vfreq[ib].size() << " words for block " << ib << ", min/max= " << vfreq[ib].getMinSymbol() << "/" << vfreq[ib].getMaxSymbol();
+      LOG(info) << "adding dictionary of " << vfreq[ib].size() << " words for block " << ib << ", min/max= " << vfreq[ib].getMinSymbol() << "/" << vfreq[ib].getMaxSymbol();
       dictBlocks->mBlocks[ib].storeDict(vfreq[ib].size(), vfreq[ib].data());
       dictBlocks = get(vdict.data()); // !!! rellocation might have invalidated dictBlocks pointer
       dictBlocks->mMetadata[ib] = vmd[ib];
@@ -976,48 +985,48 @@ void EncodedBlocks<H, N, W>::dump(const std::string& prefix, int ncol) const
   for (int ibl = 0; ibl < getNBlocks(); ibl++) {
     const auto& blc = getBlock(ibl);
     std::string ss;
-    LOGP(INFO, "{} Bloc:{} Dict: {} words", prefix, ibl, blc.getNDict());
+    LOGP(info, "{} Bloc:{} Dict: {} words", prefix, ibl, blc.getNDict());
     const auto* ptr = blc.getDict();
     for (int i = 0; i < blc.getNDict(); i++) {
       if (i && (i % ncol) == 0) {
-        LOG(INFO) << ss;
+        LOG(info) << ss;
         ss.clear();
       }
       ss += fmt::format(" {:#010x}", ptr[i]);
     }
     if (!ss.empty()) {
-      LOG(INFO) << ss;
+      LOG(info) << ss;
       ss.clear();
     }
-    LOG(INFO) << "\n";
-    LOGP(INFO, "{} Bloc:{} Data: {} words", prefix, ibl, blc.getNData());
+    LOG(info) << "\n";
+    LOGP(info, "{} Bloc:{} Data: {} words", prefix, ibl, blc.getNData());
     ptr = blc.getData();
     for (int i = 0; i < blc.getNData(); i++) {
       if (i && (i % ncol) == 0) {
-        LOG(INFO) << ss;
+        LOG(info) << ss;
         ss.clear();
       }
       ss += fmt::format(" {:#010x}", ptr[i]);
     }
     if (!ss.empty()) {
-      LOG(INFO) << ss;
+      LOG(info) << ss;
       ss.clear();
     }
-    LOG(INFO) << "\n";
-    LOGP(INFO, "{} Bloc:{} Literals: {} words", prefix, ibl, blc.getNLiterals());
+    LOG(info) << "\n";
+    LOGP(info, "{} Bloc:{} Literals: {} words", prefix, ibl, blc.getNLiterals());
     ptr = blc.getData();
     for (int i = 0; i < blc.getNLiterals(); i++) {
       if (i && (i % 20) == 0) {
-        LOG(INFO) << ss;
+        LOG(info) << ss;
         ss.clear();
       }
       ss += fmt::format(" {:#010x}", ptr[i]);
     }
     if (!ss.empty()) {
-      LOG(INFO) << ss;
+      LOG(info) << ss;
       ss.clear();
     }
-    LOG(INFO) << "\n";
+    LOG(info) << "\n";
   }
 }
 

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
@@ -38,7 +38,7 @@ struct CTFHeader : public o2::ctf::CTFDictHeader {
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF
-struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 7, uint32_t> {
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 8, uint32_t> {
 
   static constexpr size_t N = getNBlocks();
   enum Slots { BLC_bcIncTrig,
@@ -47,9 +47,11 @@ struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 7, uint32_t> {
                BLC_towerID,
                BLC_time,
                BLC_energy,
-               BLC_status
+               BLC_status,
+               // extra slot added, should not alter the order of previous ones
+               BLC_trigger // trigger bits
   };
-  ClassDefNV(CTF, 1);
+  ClassDefNV(CTF, 2);
 };
 
 } // namespace emcal

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
@@ -43,6 +43,7 @@ class TriggerRecord
 
   void setBCData(const BCData& data) { mBCData = data; }
   void setTriggerBits(uint32_t triggerbits) { mTriggerBits = triggerbits; }
+  void setTriggerBitsCompressed(uint16_t triggerbits);
   void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
   void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
   void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
@@ -50,12 +51,20 @@ class TriggerRecord
   const BCData& getBCData() const { return mBCData; }
   BCData& getBCData() { return mBCData; }
   uint32_t getTriggerBits() const { return mTriggerBits; }
+  uint16_t getTriggerBitsCompressed() const;
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
 
   void printStream(std::ostream& stream) const;
 
  private:
+  /// \enum TriggerBitsCoded_t
+  /// \brief Position of trigger classes in compressed format
+  enum TriggerBitsCoded_t {
+    TFTRIGGER,   ///< Timeframe trigger
+    PHYSTRIGGER, ///< Physics trigger
+    CALIBTRIGGER ///< Calib trigger
+  };
   BCData mBCData;        /// Bunch crossing data of the trigger
   DataRange mDataRange;  /// Index of the triggering event (event index and first entry in the container)
   uint32_t mTriggerBits; /// Trigger bits as from the Raw Data Header

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -46,6 +46,6 @@
 
 #pragma link C++ struct o2::emcal::CTFHeader + ;
 #pragma link C++ struct o2::emcal::CTF + ;
-#pragma link C++ class o2::ctf::EncodedBlocks < o2::emcal::CTFHeader, 7, uint32_t> + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::emcal::CTFHeader, 8, uint32_t> + ;
 
 #endif

--- a/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
@@ -12,12 +12,41 @@
 #include <bitset>
 #include <iostream>
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "CommonConstants/Triggers.h"
 
 namespace o2
 {
 
 namespace emcal
 {
+
+uint16_t TriggerRecord::getTriggerBitsCompressed() const
+{
+  uint16_t result(0);
+  if (mTriggerBits & o2::trigger::TF) {
+    result |= 1 << TriggerBitsCoded_t::TFTRIGGER;
+  }
+  if (mTriggerBits & o2::trigger::PhT) {
+    result |= 1 << TriggerBitsCoded_t::PHYSTRIGGER;
+  }
+  if (mTriggerBits & o2::trigger::Cal) {
+    result |= 1 << TriggerBitsCoded_t::CALIBTRIGGER;
+  }
+  return result;
+}
+
+void TriggerRecord::setTriggerBitsCompressed(uint16_t triggerbits)
+{
+  if (triggerbits & (1 << TriggerBitsCoded_t::TFTRIGGER)) {
+    mTriggerBits |= o2::trigger::TF;
+  }
+  if (triggerbits & (1 << TriggerBitsCoded_t::PHYSTRIGGER)) {
+    mTriggerBits |= o2::trigger::PhT;
+  }
+  if (triggerbits & (1 << TriggerBitsCoded_t::CALIBTRIGGER)) {
+    mTriggerBits |= o2::trigger::Cal;
+  }
+}
 
 void TriggerRecord::printStream(std::ostream& stream) const
 {

--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/CTF.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/CTF.h
@@ -40,6 +40,7 @@ struct CompressedDigits {
   CTFHeader header;
 
   // BC data
+  std::vector<uint8_t> trigger;   // trigger bits
   std::vector<uint16_t> bcInc;    // increment in BC if the same orbit, otherwise abs bc
   std::vector<uint32_t> orbitInc; // increment in orbit
   std::vector<uint8_t> nChan;     // number of fired channels
@@ -53,11 +54,11 @@ struct CompressedDigits {
 
   void clear();
 
-  ClassDefNV(CompressedDigits, 1);
+  ClassDefNV(CompressedDigits, 2);
 };
 
 /// wrapper for the Entropy-encoded clusters of the TF
-struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 6, uint32_t> {
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 7, uint32_t> {
 
   static constexpr size_t N = getNBlocks();
   enum Slots {
@@ -67,10 +68,13 @@ struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 6, uint32_t> {
 
     BLC_idChan, // channels ID: 1st on absolute, then increment
     BLC_time,   // time
-    BLC_charge  // amplitude
+    BLC_charge, // amplitude
+
+    // extra slot added, should not alter the order of previous ones
+    BLC_trigger // trigger bits
   };
 
-  ClassDefNV(CTF, 1);
+  ClassDefNV(CTF, 2);
 };
 
 } // namespace fv0

--- a/DataFormats/Detectors/FIT/FV0/src/DataFormatsFV0LinkDef.h
+++ b/DataFormats/Detectors/FIT/FV0/src/DataFormatsFV0LinkDef.h
@@ -33,7 +33,7 @@
 
 #pragma link C++ class o2::fv0::CTFHeader + ;
 #pragma link C++ class o2::fv0::CTF + ;
-#pragma link C++ class o2::ctf::EncodedBlocks < o2::fv0::CTFHeader, 6, uint32_t> + ;
+#pragma link C++ class o2::ctf::EncodedBlocks < o2::fv0::CTFHeader, 7, uint32_t> + ;
 
 #pragma link C++ class o2::fv0::RecPoints + ;
 #pragma link C++ class vector < o2::fv0::RecPoints> + ;

--- a/Detectors/CTF/test/test_ctf_io_fv0.cxx
+++ b/Detectors/CTF/test/test_ctf_io_fv0.cxx
@@ -46,11 +46,11 @@ BOOST_AUTO_TEST_CASE(CTFTest)
       ich += 1 + gRandom->Poisson(10);
     }
     auto end = channels.size();
-
+    trigger.triggerSignals = gRandom->Integer(255);
     digits.emplace_back(start, end - start, ir, trigger);
   }
 
-  LOG(INFO) << "Generated " << channels.size() << " channels in " << digits.size() << " digits " << sw.CpuTime() << " s";
+  LOG(info) << "Generated " << channels.size() << " channels in " << digits.size() << " digits " << sw.CpuTime() << " s";
 
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
     coder.encode(vec, digits, channels); // compress
   }
   sw.Stop();
-  LOG(INFO) << "Compressed in " << sw.CpuTime() << " s";
+  LOG(info) << "Compressed in " << sw.CpuTime() << " s";
 
   // writing
   {
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
     ctfImage->appendToTree(ctfTree, "FV0");
     ctfTree.Write();
     sw.Stop();
-    LOG(INFO) << "Wrote to tree in " << sw.CpuTime() << " s";
+    LOG(info) << "Wrote to tree in " << sw.CpuTime() << " s";
   }
 
   // reading
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
     BOOST_CHECK(tree);
     o2::fv0::CTF::readFromTree(vec, *(tree.get()), "FV0");
     sw.Stop();
-    LOG(INFO) << "Read back from tree in " << sw.CpuTime() << " s";
+    LOG(info) << "Read back from tree in " << sw.CpuTime() << " s";
   }
 
   std::vector<BCData> digitsD;
@@ -96,23 +96,28 @@ BOOST_AUTO_TEST_CASE(CTFTest)
     coder.decode(ctfImage, digitsD, channelsD); // decompress
   }
   sw.Stop();
-  LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";
+  LOG(info) << "Decompressed in " << sw.CpuTime() << " s";
 
   BOOST_CHECK(digitsD.size() == digits.size());
   BOOST_CHECK(channelsD.size() == channels.size());
-  LOG(INFO) << "  BOOST_CHECK digitsD.size() " << digitsD.size() << " digits.size() " << digits.size() << " BOOST_CHECK(channelsD.size()  " << channelsD.size() << " channels.size()) " << channels.size();
+  LOG(info) << "  BOOST_CHECK digitsD.size() " << digitsD.size() << " digits.size() " << digits.size() << " BOOST_CHECK(channelsD.size()  " << channelsD.size() << " channels.size()) " << channels.size();
 
   for (int i = digits.size(); i--;) {
-    const auto& dor = digits[i];
-    const auto& ddc = digitsD[i];
-    BOOST_CHECK(dor.ir == ddc.ir);
-    BOOST_CHECK(dor.ref == ddc.ref);
+    //    const auto& dor = digits[i];
+    //    const auto& ddc = digitsD[i];
+    BOOST_CHECK(digits[i] == digitsD[i]);
+    //    BOOST_CHECK(dor.ir == ddc.ir);
+    //    BOOST_CHECK(dor.ref == ddc.ref);
+    //    BOOST_CHECK(dor.mTriggers == ddc.mTriggers);
   }
   for (int i = channels.size(); i--;) {
+    /*
     const auto& cor = channels[i];
     const auto& cdc = channelsD[i];
     BOOST_CHECK(cor.pmtNumber == cdc.pmtNumber);
     BOOST_CHECK(cor.time == cdc.time);
     BOOST_CHECK(cor.chargeAdc == cdc.chargeAdc);
+    */
+    BOOST_CHECK(channels[i] == channelsD[i]);
   }
 }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -156,8 +156,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
       cellVec.emplace_back(cell);
       cellCount++;
     }
-    uint32_t trigBits = trigger[itrig];
-    trigVec.emplace_back(ir, trigBits, firstEntry, entries[itrig]);
+    auto currenttrigger = trigVec.emplace_back(ir, firstEntry, entries[itrig]);
+    currenttrigger.setTriggerBitsCompressed(trigger[itrig]);
   }
   assert(cellCount == header.nCells);
 }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -130,6 +130,15 @@ class CTFHelper
   };
 
   //_______________________________________________
+  // Trigger word
+  class Iter_trigger : public _Iter<Iter_trigger, TriggerRecord, uint16_t>
+  {
+   public:
+    using _Iter<Iter_trigger, TriggerRecord, uint16_t>::_Iter;
+    value_type operator*() const { return uint16_t(mData[mIndex].getTriggerBits() & 0xffff); }
+  };
+
+  //_______________________________________________
   class Iter_towerID : public _Iter<Iter_towerID, Cell, uint16_t>
   {
    public:
@@ -171,6 +180,9 @@ class CTFHelper
 
   Iter_entriesTrig begin_entriesTrig() const { return Iter_entriesTrig(mTrigData, false); }
   Iter_entriesTrig end_entriesTrig() const { return Iter_entriesTrig(mTrigData, true); }
+
+  Iter_trigger begin_trigger() const { return Iter_trigger(mTrigData, false); }
+  Iter_trigger end_trigger() const { return Iter_trigger(mTrigData, true); }
 
   Iter_towerID begin_towerID() const { return Iter_towerID(mCellData, false); }
   Iter_towerID end_towerID() const { return Iter_towerID(mCellData, true); }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -135,7 +135,7 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_trigger, TriggerRecord, uint16_t>::_Iter;
-    value_type operator*() const { return uint16_t(mData[mIndex].getTriggerBits() & 0xffff); }
+    value_type operator*() const { return mData[mIndex].getTriggerBitsCompressed(); }
   };
 
   //_______________________________________________

--- a/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
@@ -61,17 +61,19 @@ void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::
   };
 
   // just to get types
-  uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, tower = 0;
+  uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, tower = 0, trigger = 0;
   uint32_t orbitInc = 0;
   uint8_t status = 0;
 #define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
   // clang-format off
-  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
   MAKECODER(entries,    CTF::BLC_entriesTrig);
   MAKECODER(tower,      CTF::BLC_towerID);
   MAKECODER(cellTime,   CTF::BLC_time);
   MAKECODER(energy,     CTF::BLC_energy);
   MAKECODER(status,     CTF::BLC_status);
+  // extra slot was added in the end
+  MAKECODER(trigger,    CTF::BLC_trigger);
   // clang-format on
 }

--- a/Detectors/FIT/FV0/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/FIT/FV0/reconstruction/src/CTFCoder.cxx
@@ -50,6 +50,7 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const BCData>& dig
   cd.header.firstOrbit = dig0.ir.orbit;
   cd.header.firstBC = dig0.ir.bc;
 
+  cd.trigger.resize(cd.header.nTriggers);
   cd.bcInc.resize(cd.header.nTriggers);
   cd.orbitInc.resize(cd.header.nTriggers);
   cd.nChan.resize(cd.header.nTriggers);
@@ -66,6 +67,7 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const BCData>& dig
     const auto chanels = digit.getBunchChannelData(channelVec); // we assume the channels are sorted
 
     // fill trigger info
+    cd.trigger[idig] = digit.getTriggers().triggerSignals;
     if (prevOrbit == digit.ir.orbit) {
       cd.bcInc[idig] = digit.ir.bc - prevBC;
       cd.orbitInc[idig] = 0;
@@ -127,6 +129,9 @@ void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::
   MAKECODER(cd.idChan,    CTF::BLC_idChan);
   MAKECODER(cd.time,      CTF::BLC_time);
   MAKECODER(cd.charge,    CTF::BLC_charge);
+  //
+  // extra slot was added in the end
+  MAKECODER(cd.trigger,   CTF::BLC_trigger);
   // clang-format on
 }
 
@@ -139,6 +144,7 @@ size_t CTFCoder::estimateCompressedSize(const CompressedDigits& cd)
 #define VTP(vec) typename std::remove_reference<decltype(vec)>::type::value_type
 #define ESTSIZE(vec, slot) mCoders[int(slot)] ?                         \
   rans::calculateMaxBufferSize(vec.size(), reinterpret_cast<const o2::rans::LiteralEncoder64<VTP(vec)>*>(mCoders[int(slot)].get())->getAlphabetRangeBits(), sizeof(VTP(vec)) ) : vec.size()*sizeof(VTP(vec))
+  sz += ESTSIZE(cd.trigger,   CTF::BLC_trigger);
   sz += ESTSIZE(cd.bcInc,     CTF::BLC_bcInc);
   sz += ESTSIZE(cd.orbitInc,  CTF::BLC_orbitInc);
   sz += ESTSIZE(cd.nChan,     CTF::BLC_nChan);
@@ -148,6 +154,6 @@ size_t CTFCoder::estimateCompressedSize(const CompressedDigits& cd)
   sz += ESTSIZE(cd.charge,    CTF::BLC_charge);
   // clang-format on
 
-  LOG(INFO) << "Estimated output size is " << sz << " bytes";
+  LOG(info) << "Estimated output size is " << sz << " bytes";
   return sz;
 }


### PR DESCRIPTION
Reduction from 32 bit to 16 bit filtering the most
relevant triggers for EMCAL. For the moment
3 triggers are propagated
- TF trigger
- Physics trigger
- Calib trigger
In case other triggers will be included in the
compressed output, they need to be appended.